### PR TITLE
:bug: Fix patch-object nil removal

### DIFF
--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -369,7 +369,7 @@
                (assoc object key nil)
 
                (nil? value)
-               (dissoc object key value)
+               (dissoc object key)
 
                :else
                (assoc object key value)))


### PR DESCRIPTION
## Summary
- fix patch-object when removing keys with nil values

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_687609a72c188328b8d20ddbade5a16c